### PR TITLE
Fix src dir error.

### DIFF
--- a/src/Spryker/Shared/Twig/TwigFilesystemLoader.php
+++ b/src/Spryker/Shared/Twig/TwigFilesystemLoader.php
@@ -185,7 +185,7 @@ class TwigFilesystemLoader implements FilesystemLoaderInterface
         }
 
         $pathFragments = explode(DIRECTORY_SEPARATOR, $path);
-        $positionOfSourceDirectory = array_search('src', $pathFragments);
+        $positionOfSourceDirectory = array_search('src', array_reverse($pathFragments, true), true);
         $pathFragments[$positionOfSourceDirectory + 1] = $organization;
 
         return implode(DIRECTORY_SEPARATOR, $pathFragments);


### PR DESCRIPTION
## Problem description:

Current `TwigFilesystemLoader::getNamespacedPath()` used by `template` Twig extension yields incorrect template paths whenever a project is located under multiple `src/` directories.

## Proposed solution:

`TwigFilesystemLoader::getNamespacedPath()` should use the index of last `src` in `$pathFragments`.