### PR TITLE
Set debug mode to false if service is not set

### DIFF
--- a/src/Spryker/Zed/Twig/Communication/Plugin/Application/TwigApplicationPlugin.php
+++ b/src/Spryker/Zed/Twig/Communication/Plugin/Application/TwigApplicationPlugin.php
@@ -110,7 +110,7 @@ class TwigApplicationPlugin extends AbstractPlugin implements ApplicationPluginI
      */
     protected function getTwigOptions(ContainerInterface $container): array
     {
-        $isDebugOn = $container->get(static::SERVICE_DEBUG);
+        $isDebugOn = $container->has(static::SERVICE_DEBUG) && $container->get(static::SERVICE_DEBUG);
         $twigOptions = $this->getConfig()->getTwigOptions();
         $globalOptions = [
             'charset' => $container->get(static::SERVICE_CHARSET),


### PR DESCRIPTION
## PR Description

We added the TwigApplicationPlugin to our DependencyProvider and found this error after testing this on the preproduction environment:
```
Spryker\Service\Container\Exception\NotFoundException - The requested service "debug" was not found in the container! in "/path-to/project-zed-123456789/vendor/spryker/container/src/Spryker/Service/Container/Container.php::256"
```

This change sets `$isDebugOn` to `false` if the service is not available.

## Checklist
- [ ] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
