### PR TITLE
CC-22277 Backport for increasing Twig dependency version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   },
   "require": {
-    "twig/twig": "~1.20.0"
+    "twig/twig": "^1.44.7"
   },
   "description": "twig bundle",
   "license": "proprietary",


### PR DESCRIPTION
Branch: backport/cc-22277/twig-1.0.1
Ticket: https://spryker.atlassian.net/browse/CC-22277
Target Version: 1.0.1
Strategy: major

#### Release Table

   Module                | Release Type         | Constraint Updates
   :--------------------- | :------------------------ | :--------------------- |
   Twig  | patch                 |                      |
-----------------------------------------

#### Release Notes

{skip}

-----------------------------------------

#### Module Twig

##### Change log

Improvements

- Increased `twig/twig` dependency version to ensure a security issue on the filesystem loader is being resolved.
